### PR TITLE
Increase simulation stability by fixing boundary collision checking

### DIFF
--- a/sim.py
+++ b/sim.py
@@ -26,10 +26,14 @@ class Ball:
     def check_boundary_collision(self):
         canvas_width = self.canvas.winfo_width()
         canvas_height = self.canvas.winfo_height()
-        if self.x - self.radius <= 0 or self.x + self.radius >= canvas_width:
-            self.vx *= -1
-        if self.y - self.radius <= 0 or self.y + self.radius >= canvas_height:
-            self.vy *= -1
+        if self.x - self.radius <= 0:
+            self.vx = abs(self.vx)
+        if self.x + self.radius >= canvas_width:
+            self.vx = abs(self.vx) * -1
+        if self.y - self.radius <= 0:
+            self.vy = abs(self.vy)
+        if self.y + self.radius >= canvas_height:
+            self.vy = abs(self.vy) * -1
 
     def check_collision(self, other_ball):
         distance = ((self.x - other_ball.x) ** 2 + (self.y - other_ball.y) ** 2) ** 0.5

--- a/sim.py
+++ b/sim.py
@@ -27,13 +27,13 @@ class Ball:
         canvas_width = self.canvas.winfo_width()
         canvas_height = self.canvas.winfo_height()
         if self.x - self.radius <= 0:
-            self.vx = abs(self.vx)
+            self.vx = abs(self.vx) # Positive sign regardless of input
         if self.x + self.radius >= canvas_width:
-            self.vx = abs(self.vx) * -1
+            self.vx = abs(self.vx) * -1 # Negative sign regardless of input
         if self.y - self.radius <= 0:
-            self.vy = abs(self.vy)
+            self.vy = abs(self.vy) # Positive sign -||-
         if self.y + self.radius >= canvas_height:
-            self.vy = abs(self.vy) * -1
+            self.vy = abs(self.vy) * -1 # Negative sign -||-
 
     def check_collision(self, other_ball):
         distance = ((self.x - other_ball.x) ** 2 + (self.y - other_ball.y) ** 2) ** 0.5


### PR DESCRIPTION
When objects move to a position outside of the canvas, the function `check_boundary_collision` is supposed to take care of this by inverting the velocity, effectively making the object bounce back. 

However, when the velocity is smaller than that of the distance travelled out of the canvas, the object becomes stuck outside of the canvas. This is because the if-case in the function is triggered every single tick, and the velocity keeps inverting, causing all movement of the object to cancel out.

I split the two if-statements into four in order to be able to calculate the sign of the individual velocities instead of inverting them, and then set them accordingly. This fixes the problem and results in a more stable and deterministic simulation.